### PR TITLE
Adding back .env file to support smooth deployment

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+REACT_APP_API_HOST=https://simba-api-staging.herokuapp.com
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 
 # misc
 .DS_Store
-.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
> I’m setting up the deployment process for the frontend app, I’ll need you to move your `.env` file to `.env.local`. The `.env` file which will contain no sensible data will be committed to the repo to share configuration strings. Plus, it’s needed by the buildpack I’m using: https://github.com/mars/create-react-app-buildpack

> That’s what create-react-app@1.0.0 is doing now https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#adding-development-environment-variables-in-env